### PR TITLE
Fix: AutoDock-GPU build. Pass GPU_INCLUDE_PATH and GPU_LIBRARY_PATH to make command

### DIFF
--- a/autodock/__init__.py
+++ b/autodock/__init__.py
@@ -152,7 +152,8 @@ class Plugin(pwchemPlugin):
             targetsFlag = f' TARGETS={compCap}' if compCap else ''
 
             # Installing package
-            make_cmd = f'cd {cls._atdgpuBinary} && CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 make DEVICE=GPU OVERLAP=ON{targetsFlag}'
+            env_str = ' '.join(f'{k}={v}' for k, v in enVars.items())
+            make_cmd = f'cd {cls._atdgpuBinary} && {env_str} CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 make DEVICE=GPU OVERLAP=ON{targetsFlag}'
 
             installer.getCloneCommand(cls.getAutoDockGPUGithub(),
                                       binaryFolderName=cls._atdgpuBinary,

--- a/autodock/__init__.py
+++ b/autodock/__init__.py
@@ -152,13 +152,13 @@ class Plugin(pwchemPlugin):
             targetsFlag = f' TARGETS={compCap}' if compCap else ''
 
             # Installing package
-            env_str = ' '.join(f'{k}={v}' for k, v in enVars.items())
-            make_cmd = f'cd {cls._atdgpuBinary} && {env_str} CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 make DEVICE=GPU OVERLAP=ON{targetsFlag}'
+            envStr = ' '.join(f'{k}={v}' for k, v in enVars.items())
+            makeCmd = f'cd {cls._atdgpuBinary} && {envStr} CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 make DEVICE=GPU OVERLAP=ON{targetsFlag}'
 
             installer.getCloneCommand(cls.getAutoDockGPUGithub(),
                                       binaryFolderName=cls._atdgpuBinary,
                                       targeName='ATDGPU_CLONED') \
-                .addCommand(make_cmd, 'ATDGPU_COMPILED') \
+                .addCommand(makeCmd, 'ATDGPU_COMPILED') \
                 .addPackage(env, dependencies=['git', 'make'], default=default)
 
     @classmethod


### PR DESCRIPTION
When I installed this repo I had problems because enVars didn't connect with make command. Now it is solved.